### PR TITLE
Sample data generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN dotnet publish /src/Nesteo.Server/Nesteo.Server.csproj -c Release -o /app --self-contained --runtime debian-x64
 
 # Compile and pack sample data generation tool as self contained app
-RUN dotnet publish /src/Nesteo.Server.SampleDataGenerator/Nesteo.Server.SampleDataGenerator.csproj -c Release -o /app --self-contained --runtime debian-x64
+RUN dotnet publish /src/Nesteo.Server.SampleDataGenerator/Nesteo.Server.SampleDataGenerator.csproj -c Release -o /app --runtime debian-x64
 
 
 ### Build final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY . .
 # Compile and pack server as self contained app
 RUN dotnet publish /src/Nesteo.Server/Nesteo.Server.csproj -c Release -o /app --self-contained --runtime debian-x64
 
+# Compile and pack sample data generation tool as self contained app
+RUN dotnet publish /src/Nesteo.Server.SampleDataGenerator/Nesteo.Server.SampleDataGenerator.csproj -c Release -o /app --self-contained --runtime debian-x64
+
 
 ### Build final image
 

--- a/Nesteo.Server.SampleDataGenerator/Nesteo.Server.SampleDataGenerator.csproj
+++ b/Nesteo.Server.SampleDataGenerator/Nesteo.Server.SampleDataGenerator.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <LangVersion>8</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Nesteo.Server\Nesteo.Server.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Nesteo.Server.SampleDataGenerator/Program.cs
+++ b/Nesteo.Server.SampleDataGenerator/Program.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Nesteo.Server.Data;
+using Nesteo.Server.Data.Entities;
+using Nesteo.Server.Data.Entities.Identity;
+using Nesteo.Server.Data.Enums;
+
+namespace Nesteo.Server.SampleDataGenerator
+{
+    public static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            // Create host
+            IHost host = Server.Program.CreateHostBuilder(args).Build();
+            await Server.Program.PrepareHostAsync(host).ConfigureAwait(false);
+
+            // Request database context
+            NesteoDbContext dbContext = host.Services.GetRequiredService<NesteoDbContext>();
+
+            // Safety check
+            Console.Write("Do you want to fill the database with sample data? Please type 'yes': ");
+            if (Console.ReadLine()?.ToLower() != "yes")
+                return;
+            Console.Write("Do you really want to do this? This will DELETE all existing data! Please type 'yes': ");
+            if (Console.ReadLine()?.ToLower() != "yes")
+                return;
+
+            Console.WriteLine("Clearing database...");
+
+            // Clear database
+            dbContext.Regions.RemoveRange(dbContext.Regions);
+            dbContext.Owners.RemoveRange(dbContext.Owners);
+            dbContext.Species.RemoveRange(dbContext.Species);
+            dbContext.NestingBoxes.RemoveRange(dbContext.NestingBoxes);
+            dbContext.ReservedIdSpaces.RemoveRange(dbContext.ReservedIdSpaces);
+            dbContext.Inspections.RemoveRange(dbContext.Inspections);
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+            Console.WriteLine("Generating sample data...");
+
+            var random = new Random();
+            UserEntity user = await dbContext.Users.FirstOrDefaultAsync().ConfigureAwait(false);
+            if (user == null)
+            {
+                Console.WriteLine("Please run the server first to make sure that at least one user exists.");
+                return;
+            }
+
+            // Generate regions
+            Console.WriteLine("Generating regions...");
+            await dbContext.Regions.AddRangeAsync(
+                               Enumerable.Range(1, 20).Select(i => new RegionEntity { Name = $"Owner {i}", NestingBoxIdPrefix = ((char)('A' + (i - 1))).ToString() }))
+                           .ConfigureAwait(false);
+
+            // Generate owners
+            Console.WriteLine("Generating owners...");
+            await dbContext.Owners.AddRangeAsync(Enumerable.Range(1, 15).Select(i => new OwnerEntity { Name = $"Owner {i}" })).ConfigureAwait(false);
+
+            // Generate species
+            Console.WriteLine("Generating species...");
+            await dbContext.Species.AddRangeAsync(Enumerable.Range(1, 50).Select(i => new SpeciesEntity { Name = $"Species {i}" })).ConfigureAwait(false);
+
+            // Generate nesting boxes
+            Console.WriteLine("Generating nesting boxes...");
+            await dbContext.NestingBoxes.AddRangeAsync(Enumerable.Range(1, 400).Select(i => {
+                RegionEntity region = dbContext.Regions.Local.GetRandomOrDefault();
+
+                return new NestingBoxEntity {
+                    Id = $"{region.NestingBoxIdPrefix}{i:00000}",
+                    Region = region,
+                    OldId = random.Next(10) >= 5 ? "Old ID" : null,
+                    ForeignId = random.Next(10) >= 5 ? "Foreign ID" : null,
+                    CoordinateLongitude = 9.724372 + region.Id + (random.NextDouble() - 0.5) / 100,
+                    CoordinateLatitude = 52.353092 + (random.NextDouble() - 0.5) / 100,
+                    HangUpDate = DateTime.UtcNow.AddMonths(-6 - random.Next(24)),
+                    HangUpUser = user,
+                    Owner = dbContext.Owners.Local.GetRandomOrDefault(),
+                    Material = (Material)random.Next(4),
+                    HoleSize = (HoleSize)random.Next(7),
+                    ImageFileName = null,
+                    Comment = "This is a generated nesting box for testing purposes."
+                };
+            })).ConfigureAwait(false);
+
+            // Generate inspections
+            Console.WriteLine("Generating inspections...");
+            await dbContext.Inspections.AddRangeAsync(Enumerable.Range(1, 2000).Select(i => {
+                NestingBoxEntity nestingBox = dbContext.NestingBoxes.Local.GetRandomOrDefault();
+
+                return new InspectionEntity {
+                    NestingBox = nestingBox,
+                    InspectionDate = nestingBox.HangUpDate.GetValueOrDefault().AddMonths(random.Next(6)),
+                    InspectedByUser = user,
+                    HasBeenCleaned = false,
+                    Condition = (Condition)random.Next(3),
+                    JustRepaired = false,
+                    Occupied = true,
+                    ContainsEggs = true,
+                    EggCount = random.Next(6),
+                    ChickCount = random.Next(1, 4),
+                    RingedChickCount = 1,
+                    AgeInDays = random.Next(6),
+                    FemaleParentBirdDiscovery = (ParentBirdDiscovery)random.Next(4),
+                    MaleParentBirdDiscovery = (ParentBirdDiscovery)random.Next(4),
+                    Species = dbContext.Species.Local.GetRandomOrDefault(),
+                    ImageFileName = null,
+                    Comment = "This is a generated inspection for testing purposes."
+                };
+            })).ConfigureAwait(false);
+
+            Console.WriteLine("Saving sample data...");
+
+            // Save changes
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+            Console.WriteLine("Done.");
+        }
+
+        private static T GetRandomOrDefault<T>(this LocalView<T> localView) where T : class => localView.OrderBy(r => Guid.NewGuid()).FirstOrDefault();
+    }
+}

--- a/Nesteo.Server.sln
+++ b/Nesteo.Server.sln
@@ -17,6 +17,8 @@ ProjectSection(SolutionItems) = preProject
 	sample.env = sample.env
 EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nesteo.Server.SampleDataGenerator", "Nesteo.Server.SampleDataGenerator\Nesteo.Server.SampleDataGenerator.csproj", "{CB1814DC-8726-4158-8C7C-D7B86F93ABE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,5 +33,9 @@ Global
 		{A58836B0-4FCA-46A2-BDDF-4FB8D67C2162}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A58836B0-4FCA-46A2-BDDF-4FB8D67C2162}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A58836B0-4FCA-46A2-BDDF-4FB8D67C2162}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB1814DC-8726-4158-8C7C-D7B86F93ABE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB1814DC-8726-4158-8C7C-D7B86F93ABE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB1814DC-8726-4158-8C7C-D7B86F93ABE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB1814DC-8726-4158-8C7C-D7B86F93ABE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Nesteo.Server/Data/Entities/NestingBoxEntity.cs
+++ b/Nesteo.Server/Data/Entities/NestingBoxEntity.cs
@@ -19,11 +19,9 @@ namespace Nesteo.Server.Data.Entities
         [Required]
         public RegionEntity Region { get; set; }
 
-        [Required]
         [StringLength(100, MinimumLength = 2)]
         public string OldId { get; set; }
 
-        [Required]
         [StringLength(100, MinimumLength = 2)]
         public string ForeignId { get; set; }
 

--- a/Nesteo.Server/Data/Enums/Condition.cs
+++ b/Nesteo.Server/Data/Enums/Condition.cs
@@ -6,8 +6,8 @@ namespace Nesteo.Server.Data.Enums
     [JsonConverter(typeof(StringEnumConverter))]
     public enum Condition
     {
-        Good,
-        NeedsRepair,
-        NeedsReplacement
+        Good = 0,
+        NeedsRepair = 1,
+        NeedsReplacement = 2
     }
 }

--- a/Nesteo.Server/Migrations/20191014235003_NestingBoxRequiredIdsChanges.Designer.cs
+++ b/Nesteo.Server/Migrations/20191014235003_NestingBoxRequiredIdsChanges.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nesteo.Server.Data;
 
 namespace Nesteo.Server.Migrations
 {
     [DbContext(typeof(NesteoDbContext))]
-    partial class NesteoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20191014235003_NestingBoxRequiredIdsChanges")]
+    partial class NestingBoxRequiredIdsChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Nesteo.Server/Migrations/20191014235003_NestingBoxRequiredIdsChanges.cs
+++ b/Nesteo.Server/Migrations/20191014235003_NestingBoxRequiredIdsChanges.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Nesteo.Server.Migrations
+{
+    public partial class NestingBoxRequiredIdsChanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OldId",
+                table: "NestingBoxes",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ForeignId",
+                table: "NestingBoxes",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 100);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OldId",
+                table: "NestingBoxes",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ForeignId",
+                table: "NestingBoxes",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/Nesteo.Server/Program.cs
+++ b/Nesteo.Server/Program.cs
@@ -13,12 +13,8 @@ namespace Nesteo.Server
         {
             IHost host = CreateHostBuilder(args).Build();
 
-            // Validate and prepare the AutoMapper configuration
-            IConfigurationProvider mapperConfigurationProvider = host.Services.GetRequiredService<IConfigurationProvider>();
-#if DEBUG
-            mapperConfigurationProvider.AssertConfigurationIsValid();
-#endif
-            mapperConfigurationProvider.CompileMappings();
+            // Prepare host
+            await PrepareHostAsync(host).ConfigureAwait(false);
 
             // Run application
             await host.RunAsync().ConfigureAwait(false);
@@ -26,5 +22,17 @@ namespace Nesteo.Server
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+
+        public static Task PrepareHostAsync(IHost host)
+        {
+            // Validate and prepare the AutoMapper configuration
+            IConfigurationProvider mapperConfigurationProvider = host.Services.GetRequiredService<IConfigurationProvider>();
+#if DEBUG
+            mapperConfigurationProvider.AssertConfigurationIsValid();
+#endif
+            mapperConfigurationProvider.CompileMappings();
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ These have been set to the following values on first server start:
 
 **Password:** Admin123
 
+### Sample data generation
+
+You can use the following command to fill the database with generated sample data:
+```
+docker-compose exec nesteo-server /app/Nesteo.Server.SampleDataGenerator
+```
+
 ## Setup of a development environment
 
 #### Install the .Net Core SDK

--- a/database.sql
+++ b/database.sql
@@ -557,7 +557,53 @@ BEGIN
     IF NOT EXISTS(SELECT 1 FROM `__EFMigrationsHistory` WHERE `MigrationId` = '20190920015448_InitialCreate') THEN
 
     INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
-    VALUES ('20190920015448_InitialCreate', '2.2.6-servicing-10079');
+    VALUES ('20190920015448_InitialCreate', '3.0.0');
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+
+
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__EFMigrationsHistory` WHERE `MigrationId` = '20191014235003_NestingBoxRequiredIdsChanges') THEN
+
+    ALTER TABLE `NestingBoxes` MODIFY COLUMN `OldId` varchar(100) NULL;
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+
+
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__EFMigrationsHistory` WHERE `MigrationId` = '20191014235003_NestingBoxRequiredIdsChanges') THEN
+
+    ALTER TABLE `NestingBoxes` MODIFY COLUMN `ForeignId` varchar(100) NULL;
+
+    END IF;
+END //
+DELIMITER ;
+CALL MigrationsScript();
+DROP PROCEDURE MigrationsScript;
+
+
+DROP PROCEDURE IF EXISTS MigrationsScript;
+DELIMITER //
+CREATE PROCEDURE MigrationsScript()
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM `__EFMigrationsHistory` WHERE `MigrationId` = '20191014235003_NestingBoxRequiredIdsChanges') THEN
+
+    INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
+    VALUES ('20191014235003_NestingBoxRequiredIdsChanges', '3.0.0');
 
     END IF;
 END //


### PR DESCRIPTION
Adds a tool for easier sample data generation. Fixes #11.

I noticed an error in our database scheme: The nesting box columns for `OldId` and `ForeignId` were required. I've changed them to being optional. **After merging this PR a database migration will be required.**
This does not effect the REST API in any way.

Please take a look into the Readme for details about how to use this tool.